### PR TITLE
Multisig: support multiple actions in one request

### DIFF
--- a/multisig/Cargo.lock
+++ b/multisig/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "multisig"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "borsh",
  "near-sdk",

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 publish = false

--- a/multisig/README.md
+++ b/multisig/README.md
@@ -104,31 +104,35 @@ const result = account.signAndSendTransaction(
     ]);
 ```
 
+### Create request
+
 To create request for transfer funds:
-```javascript
-const contractName = "multisig.illia";
-const account = await near.account(contractName);
-const requestArgs = {"request": {"type": "Transfer", "receiver_id": "illia", "amount": "1000000000000000000000"}};
-const result = account.signAndSendTransaction(
-    contractName,
-    [
-        nearAPI.transactions.functionCall("add_request", Buffer.from(JSON.stringify(requestArgs)), 10000000000000, "0"),
-    ]
-);
+```bash
+near call multisig.illia add_request '{"request": {"type": "Transfer", "receiver_id": "illia", "amount": "1000000000000000000000"}}' --accountId multisig.illia
 ```
 
-To confirm a specific request:
-```javascript
-const contractName = "multisig.illia";
-const account = await near.account(contractName);
-const confirmArgs = {"request_id": 0};
-const result = account.signAndSendTransaction(
-    contractName,
-    [
-        nearAPI.transactions.functionCall("confirm", Buffer.from(JSON.stringify(confirmArgs)), 10000000000000, "0"),
-    ]
-);
+Add another key to multisig:
+```bash
+near call multisig.illia add_request '{"request": {"type": "AddKey", "public_key": "<base58 of the key>"}}' --accountId multisig.illia
 ```
+
+Change number of confirmations required to approve multisig:
+```bash
+near call multisig.illia add_request '{"request": {"type": "SetNumConfirmations", "num_confirmations": 2}}' --accountId multisig.illia
+```
+
+Returns the `request_id` of this request that can be used to confirm or see details.
+
+As a side note, for this to work one of the keys from multisig should be available in your `~/.near-credentials/<network>/<multisig-name>.json` or use `--useLedgerKey` to sign with Ledger.
+
+### Confirm request
+
+To confirm a specific request:
+```bash
+near call multisig.illia confirm '{"request_id": 0}' --accountId multisig.illia
+```
+
+### View requests
 
 To list all requests ids:
 ```bash

--- a/multisig/README.md
+++ b/multisig/README.md
@@ -19,27 +19,56 @@ All operations going forward will require `K` signatures to be performed.
 
 There are number of different request types that multisig can confirm and execute:
 ```rust
-enum MultisigRequestAction {
-  Transfer { amount: U128 },
-  AddKey { public_key: Base58PublicKey },
-  DeleteKey { public_key: Base58PublicKey },
-  FunctionCall {
+/// Lowest level action that can be performed by the multisig contract.
+pub enum MultiSigRequestAction {
+    /// Create a new account.
+    CreateAccount,
+    /// Deploys contract to receiver's account. Can upgrade given contract as well.
+    DeployContract {
+        code: Base64VecU8,
+    },
+    /// Transfers given amount to receiver.
+    Transfer {
+        amount: U128,
+    },
+    /// Stake with this account.
+    Stake {
+        public_key: Base58PublicKey,
+        stake: U128,
+    },
+    /// Adds key, either new key for multisig or full access key to another account.
+    AddKey {
+        public_key: Base58PublicKey,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        permission: Option<FunctionCallPermission>,
+    },
+    /// Deletes key, either one of the keys from multisig or key from another account.
+    DeleteKey {
+        public_key: Base58PublicKey,
+    },
+    /// Call function on behalf of this contract.
+    FunctionCall {
         method_name: String,
         args: Base64VecU8,
         deposit: U128,
-        gas: Gas
-  },
-  SetNumConfirmations { num_confirmations: u32 },
-  CreateAccount,
+        gas: U64,
+    },
+    /// Sets number of confirmations required to authorize requests.
+    /// Can not be bundled with any other actions or transactions.
+    SetNumConfirmations {
+        num_confirmations: u32,
+    },
 }
-```
 
-The request specifies `receiver_id` and set of `actions` from above:
-```rust
-struct MultisigRequest {
+/// Single transaction of the multisig request, batching actions for specific `receiver_id`.
+pub struct MultiSigRequestTransaction {
     receiver_id: AccountId,
-    actions: Vec<MultisigRequestAction>
+    actions: Vec<MultiSigRequestAction>,
 }
+
+/// Multisig request, a group of transactions that will be executed in order.
+/// If one transaction execution fails the rest will be cancelled.
+pub type MultiSigRequest = Vec<MultiSigRequestTransaction>;
 ```
 
 ### Methods
@@ -56,16 +85,20 @@ pub fn delete_request(&mut self, request_id: RequestId) {
 pub fn confirm(&mut self, request_id: RequestId) -> PromiseOrValue<bool> {
 ```
 
-### Mutlisig contract guarantees and invariants
+### State machine
 
-Guarantees:
- - Each request only gets executed after `num_confirmations` calls to `confirm` from different access keys. 
+Per each request, multisig maintains next state machine:
+ - `add_request` adds new request with empty list of confirmations.
+ - `delete_request` deletes request and ends state machine.
+ - `confirm` either adds new confirmation to list of confirmations or if there is more than `num_confirmations` confirmations with given call - switches to execution of request. `confirm` fails if request is already has been confirmed and already is executing which is determined if `confirmations` contain given `request_id`.
+ - each step of execution, schedules a promise of given set of actions on `receiver_id` and puts a callback.
+ - when callback executes, it checks if promise executed successfully: if no - stops executing the request and return failure. If yes - execute next transaction in the request if present.
+ - when all transactions are executed, remove request from `requests` and with that finish the execution of the request.   
 
 ### Gotchas
  
-User can delete access keys such that total number of different access keys will fall below `num_confirmations`, rendering contract locked.
-
-`AddKey` on another account adds full access key.
+User can delete access keys on the multisig such that total number of different access keys will fall below `num_confirmations`, rendering contract locked.
+This is due to not having a way to query blockchain for current number of access keys on the account. See discussion here - https://github.com/nearprotocol/NEPs/issues/79.
  
 ## Pre-requisites
 
@@ -120,22 +153,33 @@ const result = account.signAndSendTransaction(
 
 To create request for transfer funds:
 ```bash
-near call multisig.illia add_request '{"request": {"receiver_id": "illia", "actions": [{"type": "Transfer", "amount": "1000000000000000000000"}]}}' --accountId multisig.illia
+near call multisig.illia add_request '{"request": [{"receiver_id": "illia", "actions": [{"type": "Transfer", "amount": "1000000000000000000000"}]}]}' --accountId multisig.illia
 ```
 
 Add another key to multisig:
 ```bash
-near call multisig.illia add_request '{"request": {"receiver_id": "multisig.illia", "actions": [{"type": "AddKey", "public_key": "<base58 of the key>"}]}}' --accountId multisig.illia
+near call multisig.illia add_request '{"request": [{"receiver_id": "multisig.illia", "actions": [{"type": "AddKey", "public_key": "<base58 of the key>"}]}]}' --accountId multisig.illia
 ```
 
 Change number of confirmations required to approve multisig:
 ```bash
-near call multisig.illia add_request '{"request": {"receiver_id": "multisig.illia", "actions": [{"type": "SetNumConfirmations", "num_confirmations": 2}]}}' --accountId multisig.illia
+near call multisig.illia add_request '{"request": [{"receiver_id": "multisig.illia", "actions": [{"type": "SetNumConfirmations", "num_confirmations": 2}]}]}' --accountId multisig.illia
 ```
 
 Returns the `request_id` of this request that can be used to confirm or see details.
 
 As a side note, for this to work one of the keys from multisig should be available in your `~/.near-credentials/<network>/<multisig-name>.json` or use `--useLedgerKey` to sign with Ledger.
+
+You can also create a way more complex call that chains calling multiple different contracts:
+
+```bash
+near call multisig.illia add_request '{"request": [
+    {"receiver_id": "nep21-token", "actions": [{"type": "FunctionCall", "method": "allow", "args": "eyJhbW91bnQiOiAiMTAwIn0K", "deposit": "0", "gas": 10000000000000}]},
+    {"receiver_id": "dex", "actions": [{"type": "FunctionCall", "method": "withdraw", "args": "e30K", "deposi"t": "0", "gas": 10000000000000}]},
+]}'
+```
+
+where `eyJhbW91bnQiOiAiMTAwIn0K` is `{"amount": "100"}` encoded in base64.
 
 ### Confirm request
 

--- a/multisig/README.md
+++ b/multisig/README.md
@@ -205,6 +205,11 @@ To see confirmations for specific request:
 near view multisig.illia get_confirmations '{"request_id": 0}'
 ```
 
+Total confirmations required for any request:
+```
+near view multisig.illia get_num_confirmations
+```
+
 ### Upgrade given multisig with new code
 
 Create a request that deploys new contract code on the given account.

--- a/multisig/README.md
+++ b/multisig/README.md
@@ -204,3 +204,24 @@ To see confirmations for specific request:
 ```bash
 near view multisig.illia get_confirmations '{"request_id": 0}'
 ```
+
+### Upgrade given multisig with new code
+
+Create a request that deploys new contract code on the given account.
+Be careful about data and requiring migrations (contract updates should include data migrations going forward). 
+
+```javascript
+const fs = require('fs');
+const account = await near.account("multisig.illia");
+const contractName = "multisig.illia";
+const requestArgs = {"request": [
+    {"receiver_id": "multisig.illia", "actions": [{"type": "DeployContract", "code": fs.readFileSync("res/multisig.wasm")}]}
+]};
+const result = account.signAndSendTransaction(
+    contractName,
+    [
+        nearAPI.transactions.functionCall("add_request", Buffer.from(JSON.stringify(requestArgs)), 10000000000000, "0"),
+    ]);
+```
+
+After this, still will need to confirm this with `num_confirmations` you have setup for given contract.

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -4,42 +4,78 @@ use std::convert::TryFrom;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::collections::Map;
 use near_sdk::json_types::{Base58PublicKey, Base64VecU8, U128, U64};
-use near_sdk::{env, near_bindgen, AccountId, Promise, PromiseOrValue, PublicKey};
+use near_sdk::{env, ext_contract, near_bindgen, AccountId, Promise, PromiseOrValue, PublicKey, PromiseResult};
 use serde::{Deserialize, Serialize};
+
+/// No deposit for callbacks.
+const NO_DEPOSIT: u128 = 0;
 
 /// Unlimited allowance for multisig keys.
 const DEFAULT_ALLOWANCE: u128 = 0;
 
+/// Callback gas for transaction completion.
+const ON_TRANSACTION_COMPLETE_CALLBACK_GAS: u64 = 40_000_000_000_000;
+
 pub type RequestId = u32;
 
+/// Permissions for function call access key.
+#[derive(Clone, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+pub struct FunctionCallPermission {
+    allowance: Option<U128>,
+    receiver_id: AccountId,
+    method_names: Vec<String>,
+}
+
+/// Lowest level action that can be performed by the multisig contract.
 #[derive(Clone, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum MultiSigRequestAction {
-    Transfer {
-        amount: U128,
+    /// Create a new account.
+    CreateAccount,
+    /// Deploys contract to receiver's account. Can upgrade given contract as well.
+    DeployContract { code: Base64VecU8 },
+    /// Transfers given amount to receiver.
+    Transfer { amount: U128 },
+    /// Stake with this account.
+    Stake {
+        public_key: Base58PublicKey,
+        stake: U128,
     },
+    /// Adds key, either new key for multisig or full access key to another account.
     AddKey {
         public_key: Base58PublicKey,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        permission: Option<FunctionCallPermission>,
     },
-    DeleteKey {
-        public_key: Base58PublicKey,
-    },
+    /// Deletes key, either one of the keys from multisig or key from another account.
+    DeleteKey { public_key: Base58PublicKey },
+    /// Call function on behalf of this contract.
     FunctionCall {
         method_name: String,
         args: Base64VecU8,
         deposit: U128,
         gas: U64,
     },
-    SetNumConfirmations {
-        num_confirmations: u32,
-    },
-    CreateAccount,
+    /// Sets number of confirmations required to authorize requests.
+    /// Can not be bundled with any other actions or transactions.
+    SetNumConfirmations { num_confirmations: u32 },
 }
 
+/// Single transaction of the multisig request, batching actions for specific `receiver_id`.
 #[derive(Clone, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
-pub struct MultiSigRequest {
+pub struct MultiSigRequestTransaction {
     receiver_id: AccountId,
     actions: Vec<MultiSigRequestAction>,
+}
+
+/// Multisig request, a group of transactions that will be executed in order.
+/// If one transaction execution fails the rest will be cancelled.
+pub type MultiSigRequest = Vec<MultiSigRequestTransaction>;
+
+#[ext_contract(ext_self)]
+pub trait ExtMultiSigContract {
+    /// Callback after transaction executed to execute next transaction or finish the request.
+    fn on_transaction_completed(&mut self, request_id: RequestId, next_transaction_index: usize) -> bool;
 }
 
 #[near_bindgen]
@@ -106,15 +142,28 @@ impl MultiSigContract {
         self.confirmations.remove(&request_id);
     }
 
-    fn execute_request(&mut self, request: MultiSigRequest) -> PromiseOrValue<bool> {
-        let mut promise = Promise::new(request.receiver_id.clone());
-        let num_actions = request.actions.len();
-        for action in request.actions {
+    fn execute_request(&mut self, request_id: RequestId, transaction_index: usize, request: MultiSigRequest) -> PromiseOrValue<bool> {
+        let transaction = request[transaction_index].clone();
+        let mut promise = Promise::new(transaction.receiver_id.clone());
+        let num_actions = transaction.actions.len();
+        for action in transaction.actions {
             promise = match action {
+                MultiSigRequestAction::CreateAccount => promise.create_account(),
+                MultiSigRequestAction::DeployContract { code } => {
+                    promise.deploy_contract(code.into())
+                }
+                MultiSigRequestAction::Stake { public_key, stake } => {
+                    promise.stake(stake.into(), public_key.into())
+                }
                 MultiSigRequestAction::Transfer { amount } => promise.transfer(amount.into()),
-                MultiSigRequestAction::AddKey { public_key }
-                    if request.receiver_id == env::current_account_id() =>
-                {
+                MultiSigRequestAction::AddKey {
+                    public_key,
+                    permission,
+                } if transaction.receiver_id == env::current_account_id() => {
+                    assert!(
+                        permission.is_none(),
+                        "Permissions for access key on this contract are set by default"
+                    );
                     promise
                         .add_access_key(
                             public_key.into(),
@@ -126,18 +175,34 @@ impl MultiSigContract {
                         )
                         .into()
                 }
-                MultiSigRequestAction::AddKey { public_key } => {
-                    promise.add_full_access_key(public_key.into())
+                MultiSigRequestAction::AddKey {
+                    public_key,
+                    permission,
+                } => {
+                    if let Some(permission) = permission {
+                        promise.add_access_key(
+                            public_key.into(),
+                            permission
+                                .allowance
+                                .map(|x| x.into())
+                                .unwrap_or(DEFAULT_ALLOWANCE),
+                            permission.receiver_id,
+                            permission
+                                .method_names.join(",").into_bytes(),
+                        )
+                    } else {
+                        promise.add_full_access_key(public_key.into())
+                    }
                 }
                 MultiSigRequestAction::DeleteKey { public_key } => {
                     promise.delete_key(public_key.into())
                 }
-                MultiSigRequestAction::CreateAccount => promise.create_account(),
                 MultiSigRequestAction::SetNumConfirmations { num_confirmations } => {
-                    assert_eq!(request.receiver_id, env::current_account_id(), "Changing number of confirmations only works when receiver_id is equal to current_account_id");
+                    assert_eq!(transaction.receiver_id, env::current_account_id(), "Changing number of confirmations only works when receiver_id is equal to current_account_id");
+                    assert_eq!(request.len(), 1, "Changing the number of confirmations should be a separate request");
                     assert_eq!(
                         num_actions, 1,
-                        "Changing number of confirmations should be a separate request"
+                        "Changing the number of confirmations should be a separate request"
                     );
                     self.num_confirmations = num_confirmations;
                     return PromiseOrValue::Value(true);
@@ -155,7 +220,7 @@ impl MultiSigContract {
                 ),
             };
         }
-        promise.into()
+        promise.then(ext_self::on_transaction_completed(request_id, transaction_index, &env::current_account_id(), NO_DEPOSIT, ON_TRANSACTION_COMPLETE_CALLBACK_GAS)).into()
     }
 
     /// Confirm given request with given signing key.
@@ -170,9 +235,10 @@ impl MultiSigContract {
             self.requests.get(&request_id).is_some(),
             "No such request: either wrong number or already confirmed"
         );
+        let request = self.requests.get(&request_id).unwrap();
         assert!(
             self.confirmations.get(&request_id).is_some(),
-            "Internal error: confirmations mismatch requests"
+            "Request has already been confirmed and is currently been executed"
         );
         let mut confirmations = self.confirmations.get(&request_id).unwrap();
         assert!(
@@ -180,12 +246,8 @@ impl MultiSigContract {
             "Already confirmed this request with this key"
         );
         if confirmations.len() as u32 + 1 >= self.num_confirmations {
-            let request = self
-                .requests
-                .remove(&request_id)
-                .expect("Failed to remove existing element");
             self.confirmations.remove(&request_id);
-            self.execute_request(request)
+            self.execute_request(request_id, 0, request)
         } else {
             confirmations.insert(env::signer_account_pk());
             self.confirmations.insert(&request_id, &confirmations);
@@ -209,6 +271,36 @@ impl MultiSigContract {
             .map(|key| Base58PublicKey::try_from(key).expect("Failed to covert key to base58"))
             .collect()
     }
+
+    pub fn on_transaction_completed(&mut self, request_id: RequestId, transaction_index: usize) -> bool {
+        assert_eq!(env::predecessor_account_id(), env::current_account_id(), "Callback can only be called from the contract");
+        let success = is_promise_success();
+        assert!(success, format!("Transaction {} in request {} has failed", transaction_index, request_id));
+        assert!(
+            self.requests.get(&request_id).is_some(),
+            "No such request: either wrong number or already confirmed"
+        );
+        let request = self.requests.get(&request_id).unwrap();
+        if transaction_index + 1 == request.len() {
+            // Request is finished and can be removed.
+            self.requests.remove(&request_id);
+        } else {
+            self.execute_request(request_id, transaction_index + 1, request);
+        }
+        true
+    }
+}
+
+fn is_promise_success() -> bool {
+    assert_eq!(
+        env::promise_results_count(),
+        1,
+        "Contract expected a result on the callback"
+    );
+    match env::promise_result(0) {
+        PromiseResult::Successful(_) => true,
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -223,7 +315,7 @@ mod tests {
 
     /// Used for asserts_eq.
     /// TODO: replace with derive when https://github.com/near/near-sdk-rs/issues/165
-    impl Debug for MultiSigRequest {
+    impl Debug for MultiSigRequestTransaction {
         fn fmt(&self, _f: &mut Formatter<'_>) -> Result<(), Error> {
             panic!("Should not trigger");
         }
@@ -329,6 +421,24 @@ mod tests {
             .finish()
     }
 
+    impl MultiSigRequestTransaction {
+        fn transfer(receiver_id: AccountId, amount: u128) -> Vec<Self> {
+            vec![MultiSigRequestTransaction {
+                receiver_id,
+                actions: vec![MultiSigRequestAction::Transfer {
+                    amount: amount.into(),
+                }],
+            }]
+        }
+
+        fn set_num_confirmations(account_id: AccountId, num_confirmations: u32) -> Vec<Self> {
+            vec![MultiSigRequestTransaction {
+                receiver_id: account_id,
+                actions: vec![MultiSigRequestAction::SetNumConfirmations { num_confirmations }],
+            }]
+        }
+    }
+
     #[test]
     fn test_multi_3_of_n() {
         let amount = 1_000;
@@ -339,12 +449,7 @@ mod tests {
             amount
         ));
         let mut c = MultiSigContract::new(3);
-        let request = MultiSigRequest {
-            receiver_id: bob(),
-            actions: vec![MultiSigRequestAction::Transfer {
-                amount: amount.into(),
-            }],
-        };
+        let request = MultiSigRequestTransaction::transfer(bob(), amount);
         let request_id = c.add_request(request.clone());
         assert_eq!(c.get_request(request_id), request);
         assert_eq!(c.list_request_ids(), vec![request_id]);
@@ -367,8 +472,8 @@ mod tests {
             amount
         ));
         c.confirm(request_id);
+        assert_eq!(c.confirmations.len(), 0);
         // TODO: confirm that funds were transferred out via promise.
-        assert_eq!(c.requests.len(), 0);
     }
 
     #[test]
@@ -376,12 +481,10 @@ mod tests {
         let amount = 1_000;
         testing_env!(context_with_key(vec![1, 2, 3], amount));
         let mut c = MultiSigContract::new(1);
-        let request_id = c.add_request(MultiSigRequest {
-            receiver_id: alice(),
-            actions: vec![MultiSigRequestAction::SetNumConfirmations {
-                num_confirmations: 2,
-            }],
-        });
+        let request_id = c.add_request(MultiSigRequestTransaction::set_num_confirmations(
+            alice(),
+            2,
+        ));
         c.confirm(request_id);
         assert_eq!(c.num_confirmations, 2);
     }
@@ -392,12 +495,7 @@ mod tests {
         let amount = 1_000;
         testing_env!(context_with_key(vec![5, 7, 9], amount));
         let mut c = MultiSigContract::new(3);
-        let request_id = c.add_request(MultiSigRequest {
-            receiver_id: bob(),
-            actions: vec![MultiSigRequestAction::Transfer {
-                amount: amount.into(),
-            }],
-        });
+        let request_id = c.add_request(MultiSigRequestTransaction::transfer(bob(), amount));
         assert_eq!(c.requests.len(), 1);
         assert_eq!(c.confirmations.get(&request_id).unwrap().len(), 0);
         c.confirm(request_id);
@@ -410,12 +508,7 @@ mod tests {
         let amount = 1_000;
         testing_env!(context_with_key(vec![5, 7, 9], amount));
         let mut c = MultiSigContract::new(3);
-        let request_id = c.add_request(MultiSigRequest {
-            receiver_id: bob(),
-            actions: vec![MultiSigRequestAction::Transfer {
-                amount: amount.into(),
-            }],
-        });
+        let request_id = c.add_request(MultiSigRequestTransaction::transfer(bob(), amount));
         c.delete_request(request_id);
         assert_eq!(c.requests.len(), 0);
         assert_eq!(c.confirmations.len(), 0);

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -205,6 +205,7 @@ impl MultiSigContract {
                         "Changing the number of confirmations should be a separate request"
                     );
                     self.num_confirmations = num_confirmations;
+                    // added remove request here, never calls ext::self
                     self.requests.remove(&request_id);
                     return PromiseOrValue::Value(true);
                 }
@@ -252,10 +253,12 @@ impl MultiSigContract {
             self.execute_request(request_id, 0, request);
             // check to see if request is still there
             if self.requests.get(&request_id).is_some() {
-                PromiseOrValue::Value(false) // wasn't removed
+                // request wasn't removed during execute_request (something went wrong)
+                PromiseOrValue::Value(false)
             } else {
-                self.confirmations.remove(&request_id); // was removed, remove confirmations
-                PromiseOrValue::Value(true) // return true
+                // request was removed, remove confirmations and return true
+                self.confirmations.remove(&request_id);
+                PromiseOrValue::Value(true)
             }
         } else {
             confirmations.insert(env::signer_account_pk());

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -263,6 +263,10 @@ impl MultiSigContract {
         self.requests.keys().collect()
     }
 
+    pub fn get_num_confirmations(&self) -> u32 {
+        self.num_confirmations
+    }
+
     pub fn get_confirmations(&self, request_id: RequestId) -> Vec<Base58PublicKey> {
         self.confirmations
             .get(&request_id)


### PR DESCRIPTION
Changing support to allow multiple transactions chained to different receivers and each transaction can have multiple actions.
Also added CreateAccount and DeployContract actions that among other things allow to create and deploy new multisig enabled accounts or upgrading current account with new code.