### PR TITLE
feat(core-contracts): Add build scripts for Docker

### DIFF
--- a/lockup-factory/build_docker.sh
+++ b/lockup-factory/build_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="lockup-factory"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^build_${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=build_$NAME \
+     -w /host/$NAME \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start build_$NAME
+docker exec -it build_$NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/$NAME.wasm $DIR/../res/$NAME.wasm

--- a/lockup/build_docker.sh
+++ b/lockup/build_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="lockup_contract"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^build_${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=build_$NAME \
+     -w /host/lockup \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start build_$NAME
+docker exec -it build_$NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/$NAME.wasm $DIR/../res/$NAME.wasm

--- a/multisig/build_docker.sh
+++ b/multisig/build_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="multisig"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^build_${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=build_$NAME \
+     -w /host/$NAME \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start build_$NAME
+docker exec -it build_$NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/$NAME.wasm $DIR/../res/$NAME.wasm

--- a/staking-pool-factory/build_docker.sh
+++ b/staking-pool-factory/build_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="staking-pool-factory"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^build_${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=build_$NAME \
+     -w /host/$NAME \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start build_$NAME
+docker exec -it build_$NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/$NAME.wasm $DIR/../res/$NAME.wasm

--- a/staking-pool/build_docker.sh
+++ b/staking-pool/build_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="staking-pool"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^build_${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=build_$NAME \
+     -w /host/$NAME \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start build_$NAME
+docker exec -it build_$NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/$NAME.wasm $DIR/../res/$NAME.wasm

--- a/voting/build_docker.sh
+++ b/voting/build_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="voting"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^build_${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=build_$NAME \
+     -w /host/$NAME \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start build_$NAME
+docker exec -it build_$NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/$NAME.wasm $DIR/../res/$NAME.wasm

--- a/w-near/build_docker.sh
+++ b/w-near/build_docker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="w-near"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=$NAME \
+     -w /host/lockup \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start $NAME
+docker exec -it $NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/lockup_contract.wasm $DIR/../res/lockup_contract.wasm
+
+RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release
+cp target/wasm32-unknown-unknown/release/lockup_contract.wasm res/

--- a/whitelist/build_docker.sh
+++ b/whitelist/build_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Exit script as soon as a command fails.
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NAME="whitelist"
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^build_${NAME}\$"; then
+    echo "Container exists"
+else
+docker create \
+     --mount type=bind,source=$DIR/..,target=/host \
+     --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+     --name=build_$NAME \
+     -w /host/$NAME \
+     -e RUSTFLAGS='-C link-arg=-s' \
+     -it nearprotocol/contract-builder \
+     /bin/bash
+fi
+
+docker start build_$NAME
+docker exec -it build_$NAME /bin/bash -c "cargo build --target wasm32-unknown-unknown --release"
+
+mkdir -p res
+cp $DIR/../target/wasm32-unknown-unknown/release/$NAME.wasm $DIR/../res/$NAME.wasm


### PR DESCRIPTION
@ilblackdragon suggested adding the scripts for Docker https://github.com/near/core-contracts/pull/156#issuecomment-877596236

For now, it does not work because of https://github.com/near/near-sdk-rs/issues/465

Comment for myself
After the container on DockerHub will be updated, do not forget to check that:
- [ ] the files are executable after cloning;
- [ ] all the contracts are built successfully;
- [ ] I haven't fucked up with the final place of wasm binary