### PR TITLE
bumping rust version to 1.59.0 to fix compiling issues requiring Rust 2021

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,13 +2,13 @@ steps:
   - label: "check artifacts"
     command: |
       source ~/.cargo/env
-      rustup default 1.51.0
+      rustup default 1.56.0
       rustup target add wasm32-unknown-unknown
       ./scripts/build_all_docker.sh --check
 
   - label: "cargo test"
     command: |
       source ~/.cargo/env
-      rustup default 1.51.0
+      rustup default 1.56.0
       rustup target add wasm32-unknown-unknown
       ./scripts/test_all.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,13 +2,13 @@ steps:
   - label: "check artifacts"
     command: |
       source ~/.cargo/env
-      rustup default 1.56.0
+      rustup default 1.59.0
       rustup target add wasm32-unknown-unknown
       ./scripts/build_all_docker.sh --check
 
   - label: "cargo test"
     command: |
       source ~/.cargo/env
-      rustup default 1.56.0
+      rustup default 1.59.0
       rustup target add wasm32-unknown-unknown
       ./scripts/test_all.sh


### PR DESCRIPTION
Bumping rust version to 1.59.0 stable to resolve the following github issues:
[Github Issue 782]( https://github.com/near/near-ops/issues/782)
[Github Issue 730]( https://github.com/near/near-ops/issues/730 )
[Github Issue 727]( https://github.com/near/near-ops/issues/727)