### PR TITLE
Change link to the Near wiki

### DIFF
--- a/lockup/README.md
+++ b/lockup/README.md
@@ -4,7 +4,7 @@
 
 This contract acts as an escrow that locks and holds an owner's tokens for a lockup period.
 The contract consists of lockup and vesting processes that go simultaneously.
-A high-level overview could be found [in NEAR wiki](https://wiki.near.org/getting-started/near-token/lockups).
+A high-level overview could be found [in NEAR wiki](https://wiki.near.org/overview/tokenomics/lockups).
 
 A lockup period starts from the specified timestamp and lasts for the specified duration.
 Tokens will be unlocked linearly.


### PR DESCRIPTION
A link to Wiki page about lockups changed, so the one in README was broken.